### PR TITLE
Fix retlogo file serving

### DIFF
--- a/squad/views.py
+++ b/squad/views.py
@@ -17,10 +17,13 @@ def retxml(request, user):
         member = Member.objects.get(nickname=user)
         return render(request, 'squad.xml', {'member': member})
     except ObjectDoesNotExist:
-        return HttpResponse(None)
+        return HttpResponse(status=404)
 
 def retlogo(request):
-    f = open(settings.STATIC_ROOT+'slogo.paa', 'rb')
+    """Return the squad logo as a binary stream."""
+    logo_path = os.path.join(settings.STATIC_ROOT, 'slogo.paa')
+    with open(logo_path, 'rb') as f:
+        data = f.read()
 
-    return HttpResponse(f, mimetype='application/octet-stream')
+    return HttpResponse(data, content_type='application/octet-stream')
 


### PR DESCRIPTION
## Summary
- fix retxml to return HTTP 404 on missing user
- correctly read binary data when serving `slogo.paa`

## Testing
- `python manage.py test` *(fails: ImportError from incompatible Django version)*

------
https://chatgpt.com/codex/tasks/task_e_6841934e1390832dada5c3dc7c17afde