### PR TITLE
Add README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Reborn Community Control Center
+
+This repository contains a small Django project used for managing the Reborn community members and servers. It exposes a basic website and XML feed that can be consumed by games like Arma.
+
+## Features
+
+- Django 4 based project.
+- Admin interface provided by [django-grappelli](https://github.com/sehmaschine/django-grappelli).
+- Displays a list of members grouped by rank.
+- Provides an XML endpoint and binary logo file for use in third‑party tools.
+- Comes with a basic test suite.
+
+## Requirements
+
+- Python 3.11+
+- Django 4.2
+- django-grappelli 3.x
+
+All required Python packages are listed in [requirements.txt](requirements.txt).
+
+## Installation
+
+1. Create and activate a virtual environment (recommended):
+
+   ```bash
+   python3 -m venv env
+   source env/bin/activate
+   ```
+
+2. Install the dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run migrations to set up the database:
+
+   ```bash
+   python manage.py migrate
+   ```
+
+## Running the development server
+
+Execute the following command and open <http://localhost:8000/squad/> in a browser:
+
+```bash
+python manage.py runserver
+```
+
+The admin interface is available at `/admin/`.
+
+## Running tests
+
+The project includes a small test suite located in `squad/tests.py`. Run the tests with:
+
+```bash
+python manage.py test
+```
+
+## Project layout
+
+```
+├── Reborn/              # Project settings and URL configuration
+├── squad/               # Application with models, views and tests
+├── static/              # CSS and logo assets
+├── templates/           # HTML and XML templates
+└── manage.py            # Django management script
+```
+
+For additional details on configuring the project, see [docs/local_setup.md](docs/local_setup.md).
+

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -1,0 +1,11 @@
+# Local Setup
+
+This page provides a brief guide for setting up a development environment.
+
+1. Ensure Python 3.11 or later is installed.
+2. Create a virtual environment and install dependencies using `pip install -r requirements.txt`.
+3. Run `python manage.py migrate` to create the SQLite database.
+4. (Optional) Create a superuser to access the Django admin with `python manage.py createsuperuser`.
+5. Start the development server via `python manage.py runserver`.
+
+The default database is SQLite and is stored in `db.sqlite3`. Feel free to adjust the settings in `Reborn/settings.py` if you need a different database engine.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+django>=4.2,<4.3
+django-grappelli>=3.0,<4.0


### PR DESCRIPTION
## Summary
- document setup and usage in README
- add a docs folder with local setup details
- list Django dependencies in requirements.txt

## Testing
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6841c686aa18832dac594332c280ec15